### PR TITLE
make "respond to" recognize HTTP Accept header request for JSON

### DIFF
--- a/src/RequestDispatcher.php
+++ b/src/RequestDispatcher.php
@@ -177,6 +177,10 @@ class RequestDispatcher
       isset($_GET['json']) ||
       $this->outputFormat === 'json' ||
       (
+          ! empty( $_SERVER['HTTP_ACCEPT'] ) &&
+          strtolower( $_SERVER['HTTP_ACCEPT'] ) == 'application/json'
+      ) ||
+      (
         ! empty( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && 
         strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) == 'xmlhttprequest' &&
         $this->outputFormat !== 'html'

--- a/tests/unit/RouterTest.php
+++ b/tests/unit/RouterTest.php
@@ -1380,6 +1380,32 @@ class RouterTest extends \Codeception\Test\Unit{
     );
   }
 
+    function testHandlerReturningRespondToJsonToAcceptJson()
+    {
+      $_SERVER['HTTP_ACCEPT'] = 'application/json';
+
+      \WP_Mock::wpFunction( 'wp_send_json', array(
+        'times' => 1,
+        'return' => 'json data output',
+      ) );
+
+      $router = Router::create();
+
+      $router->get('users', 'get_users', function(){
+        return ['respond_to' => [
+          'json' => 'irrelevant data as wp_send_json return data is mocked above',
+          'html' => function(){
+            return 'users view loaded';
+          }
+        ]];
+      });
+
+      $this->assertEquals(
+        'json data output',
+        $router->dispatch('GET', 'users')
+      );
+    }
+
   function testHandlerReturningRespondToJsonToRequestWithJsonGetParam()
   {
     \WP_Mock::wpFunction( 'wp_send_json', array(


### PR DESCRIPTION
This pull request adds to the conditional in `RequestDispatcher::shouldReturnJson` to look for the HTTP Accept header.