### PR TITLE
Remove $this is static method. Update error message.

### DIFF
--- a/src/RouteParser.php
+++ b/src/RouteParser.php
@@ -74,7 +74,7 @@ abstract class RouteParser
   {
     if( ! is_callable($handler) ){
       throw new Exception\InvalidRouteHandlerException(
-        "Invalid handler for '" . $this->name . "' route."
+        "Invalid route handle."
       );
     }
   }


### PR DESCRIPTION
Causing a fatal error: Fatal Error: Using $this when not in object context